### PR TITLE
Feat/create customer search api

### DIFF
--- a/src/application/customer/customer.controller.spec.ts
+++ b/src/application/customer/customer.controller.spec.ts
@@ -2,7 +2,6 @@ import { Test, TestingModule } from "@nestjs/testing"
 import { CustomerController } from "./customer.controller"
 import { CustomerModule } from "./customer.module"
 import { PrismaService } from "../../infrastructure/prisma/prisma.service"
-import * as request from 'supertest'
 
 const fixedCustomerId = 'existCustomerId01234567890'
 

--- a/src/application/customer/customer.controller.ts
+++ b/src/application/customer/customer.controller.ts
@@ -32,6 +32,17 @@ export class CustomerController {
     }
   }
 
+  @Get('/search/:name')
+  async findByName(@Param('name') name: string) {
+    const customers = await this.customerService.findByName(name)
+    return {
+      statusCode: HttpStatus.OK,
+      items: {
+        customers
+      }
+    }
+  }
+
   @Post()
   async create(@Body() data: CustomerCreateArgs) {
     const customer: Customer = {

--- a/src/application/customer/customer.service.ts
+++ b/src/application/customer/customer.service.ts
@@ -20,4 +20,8 @@ export class CustomerService {
   async findAll(): Promise<Customer[]> {
     return await this.customerRepository.findAll()
   }
+  
+  async findByName(name: string): Promise<Customer[]> {
+    return await this.customerRepository.findByName(name)
+  }
 }

--- a/src/application/product/product.controller.spec.ts
+++ b/src/application/product/product.controller.spec.ts
@@ -2,7 +2,6 @@ import { Test, TestingModule } from "@nestjs/testing"
 import { ProductController } from "./product.controller"
 import { ProductModule } from "./product.module"
 import { PrismaService } from "../../infrastructure/prisma/prisma.service"
-import * as request from 'supertest'
 
 const fixedProductId = 'rintest'
 

--- a/src/domain/repositories/customer.repository.interface.ts
+++ b/src/domain/repositories/customer.repository.interface.ts
@@ -4,4 +4,5 @@ export interface CustomerRepositoryInterface {
   create(customer: Customer): Promise<Customer>
   findOne(id: string): Promise<Customer>
   findAll(): Promise<Customer[]>
+  findByName(name: string): Promise<Customer[]>
 }

--- a/src/infrastructure/prisma/customer.prisma.repository.ts
+++ b/src/infrastructure/prisma/customer.prisma.repository.ts
@@ -50,7 +50,6 @@ export class CustomerPrismaRepository implements CustomerRepositoryInterface {
   }
 
   async findOne(userId: string): Promise<Customer> {
-    console.log('customer-prisma-repository')
     const customer = await this.prisma.customer.findFirst({
       where: {
         id: userId

--- a/src/infrastructure/prisma/customer.prisma.repository.ts
+++ b/src/infrastructure/prisma/customer.prisma.repository.ts
@@ -48,6 +48,7 @@ export class CustomerPrismaRepository implements CustomerRepositoryInterface {
       createdCustomer.updatedBy
     )
   }
+
   async findOne(userId: string): Promise<Customer> {
     console.log('customer-prisma-repository')
     const customer = await this.prisma.customer.findFirst({
@@ -77,7 +78,18 @@ export class CustomerPrismaRepository implements CustomerRepositoryInterface {
       customer.updatedBy
     )
   }
+
   async findAll(): Promise<Customer[]> {
     return await this.prisma.customer.findMany({})
+  }
+
+  async findByName(name: string): Promise<Customer[]> {
+    return await this.prisma.customer.findMany({
+      where: {
+        name: {
+          contains: name,
+        }
+      }
+    })
   }
 }

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -1,24 +1,23 @@
-import { Test, TestingModule } from '@nestjs/testing';
-import { INestApplication } from '@nestjs/common';
-import * as request from 'supertest';
-import { AppModule } from './../src/app.module';
+import { Test, TestingModule } from '@nestjs/testing'
+import { INestApplication } from '@nestjs/common'
+import * as request from 'supertest'
+import { AppModule } from './../src/app.module'
 
 describe('AppController (e2e)', () => {
-  let app: INestApplication;
+  let app: INestApplication
 
   beforeEach(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports: [AppModule],
-    }).compile();
+    }).compile()
 
-    app = moduleFixture.createNestApplication();
-    await app.init();
-  });
-
-  it('/ (GET)', () => {
+    app = moduleFixture.createNestApplication()
+    await app.init()
+  })
+it('/ (GET)', () => {
     return request(app.getHttpServer())
       .get('/')
       .expect(200)
-      .expect('Hello World!');
-  });
-});
+      .expect('Hello World!')
+  })
+})


### PR DESCRIPTION
## 関連チケットのリンク
なし

## やったこと
customer/search/:keyword で社名検索ができるように機能追加

## やらないこと
社名以外の住所などの検索はスコープ外(やるなら都道府県とかはコード持ちにした方がいい)

## 仕様詳細
keywordで与えられた文字列で曖昧検索、取得した結果をObjectの配列で返す

## 動作確認方法および確認結果
Postmanで対応

## その他レビュワーへの共有事項(実装上の懸念点や注意点などがあれば)
