### PR TITLE
CORS対応(修正)

### DIFF
--- a/.env
+++ b/.env
@@ -5,3 +5,4 @@
 # See the documentation for all the connection string options: https://pris.ly/d/connection-strings
 
 DATABASE_URL="mysql://root:root@localhost:33060/order-management"
+FRONTEND_URL="http://localhost:4000"

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,7 +7,7 @@ async function bootstrap() {
 
   // CORS設定
   const corsOptions: CorsOptions = {
-    origin: 'http://localhost:3001',
+    origin: process.env.FRONTEND_URL,
     methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
     credentials: true,
   }


### PR DESCRIPTION
## 関連チケットのリンク
なし

## やったこと
フロントエンドのURLをhttp://localhost:4000に固定(仮修正)

## やらないこと
- 

## 仕様詳細
フロントエンド(http://localhost:4000)からAPIにアクセスできるようにする

## 動作確認方法および確認結果
フロントエンド(http://localhost:4000)からAPIを呼び出し、レスポンスを受け取れることを確認

## その他レビュワーへの共有事項(実装上の懸念点や注意点などがあれば)
特になし